### PR TITLE
Fix TypeError when calling $.fn.off() with no args.

### DIFF
--- a/jquery.selector-set.js
+++ b/jquery.selector-set.js
@@ -116,6 +116,9 @@
   //
   // Returns nothing.
   $.event.remove = function(elem, types, handler, selector, mappedTypes) {
+    if (typeof types === "undefined") {
+      types = "";
+    }
     if (elem === document && !types.match(/\./) && selector) {
       var ts = types.match(/\S+/g);
       var t = ts.length;

--- a/test/test.js
+++ b/test/test.js
@@ -18,6 +18,33 @@ test('bind/unbind click handler to document', function() {
   equal(clicked, 2);
 });
 
+test('unbind all event handlers from document', function() {
+  var clicked1 = 0;
+  var clicked2 = 0;
+
+  function handle1() {
+    clicked1++;
+  }
+
+  function handle2() {
+    clicked2++;
+  }
+
+  equal(clicked1, 0);
+  equal(clicked2, 0);
+
+  $(document).on('click', handle1);
+  $(document).on('click', handle2);
+  $(document).trigger('click');
+  equal(clicked1, 1);
+  equal(clicked2, 1);
+
+  $(document).off();
+  $(document).trigger('click');
+  equal(clicked1, 1);
+  equal(clicked2, 1);
+});
+
 test('bind/unbind click handler to document element', function() {
   var clicked = 0;
 


### PR DESCRIPTION
jQuery lets you call `off()` with no arguments: http://api.jquery.com/off/#off

It unbinds all event handlers from the element.

This invokes `$.event.remove` with an undefined `types` argument, which caused an error when `jquery.selector-set.js` is loaded:

```
TypeError: Cannot call method 'match' of undefined
    at Object.$.event.remove (file://localhost/Users/dev/projects/jquery-selector-set/jquery.selector-set.js:122:37)
    at HTMLDocument.<anonymous> (http://code.jquery.com/jquery-2.0.3.js:5113:17)
    at Function.jQuery.extend.each (http://code.jquery.com/jquery-2.0.3.js:590:23)
    at jQuery.fn.jQuery.each (http://code.jquery.com/jquery-2.0.3.js:237:17)
    at jQuery.fn.extend.off (http://code.jquery.com/jquery-2.0.3.js:5112:15)
    at Object.<anonymous> (file://localhost/Users/dev/projects/jquery-selector-set/test/test.js:42:15)
```
