### PR TITLE
Precompile selector only if sizzle is installed.

### DIFF
--- a/jquery.selector-set.js
+++ b/jquery.selector-set.js
@@ -99,7 +99,11 @@
         }
         handleObj.selectorSet.add(selector, handler);
         $.expr.cacheLength++;
-        $.find.compile(selector);
+
+        // if sizzle is available
+        if ($.find.compile) {
+          $.find.compile(selector);
+        }
       }
     } else {
       originalEventAdd.call(this, elem, types, handler, data, selector);


### PR DESCRIPTION
When jQuery is built without the sizzle selector engine (`grunt custom:-sizzle`), the `$.find.compile` function isn't available. This branch only precompiles the selectors when sizzle is installed.
