### PR TITLE
Fix delegation of events originating from SVG in IE

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -72,12 +72,16 @@ module.exports = function(grunt) {
             'http://127.0.0.1:9999/test/unpatched/1-11.html',
             'http://127.0.0.1:9999/test/unpatched/2-0.html',
             'http://127.0.0.1:9999/test/unpatched/2-1.html',
+            'http://127.0.0.1:9999/test/unpatched/3-0.html',
+            'http://127.0.0.1:9999/test/unpatched/3-1.html',
             'http://127.0.0.1:9999/test/patched/1-8.html',
             'http://127.0.0.1:9999/test/patched/1-9.html',
             'http://127.0.0.1:9999/test/patched/1-10.html',
             'http://127.0.0.1:9999/test/patched/1-11.html',
             'http://127.0.0.1:9999/test/patched/2-0.html',
-            'http://127.0.0.1:9999/test/patched/2-1.html'
+            'http://127.0.0.1:9999/test/patched/2-1.html',
+            'http://127.0.0.1:9999/test/patched/3-0.html',
+            'http://127.0.0.1:9999/test/patched/3-1.html'
           ],
           tunnelTimeout: 5,
           build: process.env.TRAVIS_JOB_ID,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,18 +28,25 @@ module.exports = function(grunt) {
       src: {
         src: ['jquery.selector-set.js'],
         options: {
-          jquery: true
+          jquery: true,
+          globals: {
+            define: true,
+            require: true,
+            module: true
+          }
+        }
+      },
+      srcnext: {
+        src: ['jquery.selector-set.next.js'],
+        options: {
+          esnext: true,
+          module: true
         }
       },
       test: {
         options: {
           jquery: true,
-          globals: {
-            'QUnit': false,
-            'test': false,
-            'ok': false,
-            'equal': false
-          }
+          qunit: true
         },
         src: ['test/*.js']
       }

--- a/jquery.selector-set.js
+++ b/jquery.selector-set.js
@@ -18,7 +18,7 @@
 
   // Throw an error if SelectorSet dependency is undefined.
   if (!SelectorSet) {
-    throw "SelectorSet undefined - https://github.com/josh/jquery-selector-set";
+    throw 'SelectorSet undefined - https://github.com/josh/jquery-selector-set';
   }
 
   // Internal: Compute event propagation path using SelectorSet's fast match.

--- a/jquery.selector-set.js
+++ b/jquery.selector-set.js
@@ -42,7 +42,7 @@
       if (matches.length) {
         handlerQueue.push({elem: cur, handlers: matches});
       }
-    } while (cur = cur.parentElement);
+    } while (cur = cur.parentNode);
 
     return handlerQueue;
   }

--- a/jquery.selector-set.next.js
+++ b/jquery.selector-set.next.js
@@ -30,7 +30,7 @@ function selectorSetHandlers(event) {
     if (matches.length) {
       handlerQueue.push({elem: cur, handlers: matches});
     }
-  } while (cur = cur.parentElement);
+  } while (cur = cur.parentNode);
 
   return handlerQueue;
 }

--- a/jquery.selector-set.next.js
+++ b/jquery.selector-set.next.js
@@ -1,9 +1,9 @@
 // jQuery SelectorSet
 
-import $ from 'jquery'
-import SelectorSet from 'selector-set'
+import $ from 'jquery';
+import SelectorSet from 'selector-set';
 
-var document = window.document;
+var document = window.document; // jshint ignore:line
 var SelectorSet = window.SelectorSet;
 var originalEventAdd = $.event.add;
 var originalEventRemove = $.event.remove;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "bower": "1.3.12",
     "grunt": "0.4.5",
     "grunt-contrib-connect": "0.9.0",
-    "grunt-contrib-jshint": "0.10.0",
+    "grunt-contrib-jshint": "0.11.3",
     "grunt-contrib-qunit": "0.5.2",
     "grunt-contrib-watch": "0.6.1",
     "grunt-saucelabs": "8.4.1"

--- a/test/patched/3-0.html
+++ b/test/patched/3-0.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Test Suite</title>
+  <link rel="stylesheet" href="../../bower_components/qunit/qunit/qunit.css">
+</head>
+<body>
+  <div id="qunit"></div>
+  <div id="qunit-fixture"></div>
+
+  <script src="http://code.jquery.com/jquery-3.0.0.js"></script>
+  <script src="../../bower_components/qunit/qunit/qunit.js"></script>
+  <script src="./../saucelabs.js"></script>
+  <script src="../../bower_components/selector-set/selector-set.js"></script>
+  <script src="../../jquery.selector-set.js"></script>
+
+  <script src="./../test.js"></script>
+</body>
+</html>

--- a/test/patched/3-1.html
+++ b/test/patched/3-1.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Test Suite</title>
+  <link rel="stylesheet" href="../../bower_components/qunit/qunit/qunit.css">
+</head>
+<body>
+  <div id="qunit"></div>
+  <div id="qunit-fixture"></div>
+
+  <script src="http://code.jquery.com/jquery-3.1.0.js"></script>
+  <script src="../../bower_components/qunit/qunit/qunit.js"></script>
+  <script src="./../saucelabs.js"></script>
+  <script src="../../bower_components/selector-set/selector-set.js"></script>
+  <script src="../../jquery.selector-set.js"></script>
+
+  <script src="./../test.js"></script>
+</body>
+</html>

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,9 @@
+module('jquery.selector-set', {
+  afterEach: function() {
+    document.getElementById('qunit-fixture').innerHTML = '';
+  }
+});
+
 test('bind/unbind click handler to document', function() {
   var clicked = 0;
 
@@ -418,4 +424,19 @@ test('stopImmediatePropagation from delegated document click handler', function(
   equal(event.isDefaultPrevented(), false);
   equal(event.isPropagationStopped(), false);
   equal(event.result, undefined);
+});
+
+test('SVG as origin of event', function() {
+  document.getElementById('qunit-fixture').innerHTML =
+    '<svg height="4" version="1.1" viewBox="0 0 4 4" width="4">' +
+    '<rect x="0" y="0" width="4" height="4"></rect></svg>';
+
+  var target;
+  $(document).on('click', '#qunit-fixture', function(event) {
+    target = event.target;
+  });
+
+  var rect = document.querySelector('svg rect');
+  $(rect).trigger('click');
+  equal(target, rect);
 });

--- a/test/unpatched/3-0.html
+++ b/test/unpatched/3-0.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Test Suite</title>
+  <link rel="stylesheet" href="../../bower_components/qunit/qunit/qunit.css">
+</head>
+<body>
+  <div id="qunit"></div>
+  <div id="qunit-fixture"></div>
+
+  <script src="http://code.jquery.com/jquery-3.0.0.js"></script>
+  <script src="../../bower_components/qunit/qunit/qunit.js"></script>
+  <script src="./../saucelabs.js"></script>
+  <script src="../../bower_components/selector-set/selector-set.js"></script>
+
+  <script src="./../test.js"></script>
+</body>
+</html>

--- a/test/unpatched/3-1.html
+++ b/test/unpatched/3-1.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Test Suite</title>
+  <link rel="stylesheet" href="../../bower_components/qunit/qunit/qunit.css">
+</head>
+<body>
+  <div id="qunit"></div>
+  <div id="qunit-fixture"></div>
+
+  <script src="http://code.jquery.com/jquery-3.1.0.js"></script>
+  <script src="../../bower_components/qunit/qunit/qunit.js"></script>
+  <script src="./../saucelabs.js"></script>
+  <script src="../../bower_components/selector-set/selector-set.js"></script>
+
+  <script src="./../test.js"></script>
+</body>
+</html>


### PR DESCRIPTION
In IE 11, SVG elements don't have the `parentElement` property.

/cc @josh