### PR TITLE
fix import binding in next.js

### DIFF
--- a/jquery.selector-set.next.js
+++ b/jquery.selector-set.next.js
@@ -1,10 +1,10 @@
 // jQuery SelectorSet
 
 import $ from 'jquery';
-import SelectorSet from 'selector-set';
+import ImportedSelectorSet from 'selector-set';
 
 var document = window.document; // jshint ignore:line
-var SelectorSet = window.SelectorSet;
+var SelectorSet = ImportedSelectorSet || window.SelectorSet;
 var originalEventAdd = $.event.add;
 var originalEventRemove = $.event.remove;
 var handleObjs = {};


### PR DESCRIPTION
There is an issue in the next.js version of this script - whereby it ties to
set up an import binding for `SelectorSet` but also declares a `SelectorSet`
variable. This is problematic because spec conformant platforms make import
bindings immutable and so the code throws an error.

This fixes the problem by renaming the import to `ImportedSelectorSet` and
uses a logical or to select between the imported and window binding.